### PR TITLE
Add example configuration file for Redis cache

### DIFF
--- a/examples/redis.yaml
+++ b/examples/redis.yaml
@@ -18,11 +18,12 @@ cache:
   ttl: 300s # Default TTL for cached entries
   capacity: 0 # Not applicable to Redis
   maxContentSize: 1048576 # Max item size in bytes
-  redisConfig:
-    host: "127.0.0.1" # Redis server address
-    port: 6379 # Redis server port
-    db: 0 # Database index
-    password: "" # Optional password for Redis connection
+  redis:
+    address: "127.0.0.1:6379"  # Redis server address with port
+    password: ""               # Optional password
+    db: 0                      # Database index
+    namespace: "hermyx:"       # Optional key namespace/prefix
+
   keyConfig:
     type: ["path", "query"]
     excludeMethods: ["POST", "PUT", "DELETE"]

--- a/examples/redis.yaml
+++ b/examples/redis.yaml
@@ -1,0 +1,44 @@
+# Global logging options (LogConfig)
+log:
+  toFile: false # Write logs to file if true
+  filePath: "" # Path to log file when toFile=true
+  toStdout: true # Mirror logs to stdout
+  prefix: "[hermyx]" # Log line prefix
+  flags: 0 # Bit flags for log formatting (app-defined)
+  debugEnabled: false # Enable debug logs
+
+# Server settings (ServerConfig)
+server:
+  port: 8080 # TCP port for the proxy
+
+# Default cache backend (CacheConfig)
+cache:
+  type: "redis" # memory|disk|redis
+  enabled: true # Master toggle for caching
+  ttl: 300s # Default TTL for cached entries
+  capacity: 0 # Not applicable to Redis
+  maxContentSize: 1048576 # Max item size in bytes
+  redisConfig:
+    host: "127.0.0.1" # Redis server address
+    port: 6379 # Redis server port
+    db: 0 # Database index
+    password: "" # Optional password for Redis connection
+  keyConfig:
+    type: ["path", "query"]
+    excludeMethods: ["POST", "PUT", "DELETE"]
+
+# Local storage path (for fallback or misc data)
+storage:
+  path: "/var/cache/hermyx"
+
+# Route list (RouteConfig[])
+routes:
+  - name: "session-cache"
+    path: "/session"
+    target: "http://127.0.0.1:9002"
+    cache:
+      type: "redis"
+      enabled: true
+      ttl: 600s
+      keyConfig:
+        type: ["path", "query"]

--- a/readme.md
+++ b/readme.md
@@ -187,7 +187,7 @@ routes:
 
 ## 🔧 Logging Configuration Example
 
-Hermyx supports flexible logging via the `log` section in the YAML config file. Below is an example of configuration and explanation of each field:
+Hermyx supports flexible logging via the `log` section in the YAML config file. Below is an example configuration and an explanation of each field:
 
 ```yaml
 log:

--- a/readme.md
+++ b/readme.md
@@ -185,6 +185,21 @@ routes:
 
 ---
 
+## 🔧 Logging Configuration Example
+
+Hermyx supports flexible logging via the `log` section in the YAML config file. Below is an example of configuration and explanation of each field:
+
+```yaml
+log:
+  toFile: true                 # write logs to a file when true
+  filePath: "./hermyx.log"     # path to log file
+  toStdout: true                # whether to also write logs to stdout
+  prefix: "[Hermyx] "          # prefix included at start of each log line
+  flags: 0                      # Go log flags: combination of log.Ldate, log.Ltime, log.Lshortfile, etc.
+  debugEnabled: true           # when true, extra debug logs will be emitted
+
+
+
 ## 💡 Cache Types
 
 Hermyx supports multiple caching backends. Choose one depending on your use case:


### PR DESCRIPTION
### 💡 Description
The `examples/` directory already contained `memory.yaml` and `disk.yaml`.  
In this PR, I have added a new example for Redis caching: `examples/redis.yaml`.

The Redis example includes detailed comments explaining all configuration fields such as `ttl`, `host`, `port`, `db`, and key construction rules.

### 🎯 Purpose
Helps users quickly understand how to configure Hermyx to use Redis as the cache backend.

### ✅ Changes
- Created `examples/redis.yaml` in the examples/ directory

### 📝 Notes
If any changes or improvements are needed for consistency or formatting, please let me know!  

### 🏷️ Labels
documentation, hacktoberfest-accepted, examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Redis-backed cache configuration example covering global and per-route caching, TTLs, key namespaces, path/query filtering, connection options, and an example exclude list for HTTP methods.
  * Introduced a Logging Configuration Example detailing stdout mirroring, optional file output, prefix/flag options, and debug toggles with a YAML snippet and explanations.
  * Added routing guidance showing endpoint-to-target mapping with optional per-route caching and storage fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->