### PR TITLE
Add detailed usage and examples to CLI help output

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,41 +16,93 @@ Usage:
   hermyx <command> [options]
 
 Available Commands:
-	up        Start the Hermyx reverse proxy
-	down 			Close the Hermyx reverse proxy
-	init 			Scaffold hermyx config yaml.
-  	help      		Show help for a command
-  	version      		Display hermyx version
+  up        Start the Hermyx reverse proxy
+  down      Close the Hermyx reverse proxy
+  init      Scaffold hermyx config yaml.
+  help      Show help for a command
+  version   Display hermyx version
+
+Examples:
+
+  hermyx up --config ./hermyx.config.yaml
+  hermyx down --config ./hermyx.config.yaml
+  hermyx init
+  hermyx help up
 
 Run 'hermyx help <command>' for details on a specific command.`)
 }
 
 func printInitHelp() {
-	fmt.Println(`Usage:
+	fmt.Println(`hermyx init - scaffold a default Hermyx config YAML file
+
+Creates a starter hermyx.config.yaml (or the path given via --config) with
+default logging, server, storage, and cache sections pre-filled so you can
+start editing right away instead of writing a config from scratch.
+
+Usage:
   hermyx init [--config <path>]
 
 Options:
-  --config   Path to Hermyx config YAML file (default: ./hermyx.config.yaml)`)
+  --config   Path to Hermyx config YAML file to create (default: ./hermyx.config.yaml)
+
+Examples:
+  # Scaffold ./hermyx.config.yaml in the current directory
+  hermyx init
+
+  # Scaffold a config at a custom path
+  hermyx init --config ./configs/prod.yaml`)
 }
 
 func printUpHelp() {
-	fmt.Println(`Usage:
+	fmt.Println(`hermyx up - start the Hermyx reverse proxy
+
+Reads the given config file, starts the proxy server on the configured port,
+and begins routing and caching requests according to the configured routes.
+Writes a PID file under the configured storage path so 'hermyx down' can
+later find and stop this instance. Runs in the foreground until it receives
+a shutdown signal (Ctrl+C) or is stopped via 'hermyx down'.
+
+Usage:
   hermyx up [--config <path>]
 
 Options:
-  --config   Path to Hermyx config YAML file (default: ./hermyx.config.yaml)`)
+  --config   Path to Hermyx config YAML file (default: ./hermyx.config.yaml)
+
+Examples:
+  # Start using ./hermyx.config.yaml in the current directory
+  hermyx up
+
+  # Start using a specific config file
+  hermyx up --config ./configs/prod.yaml`)
 }
 
 func printDownHelp() {
-	fmt.Println(`Usage:
+	fmt.Println(`hermyx down - stop a running Hermyx reverse proxy
+
+Reads the PID file recorded by a running 'hermyx up' instance (found via the
+storage path in the given config file) and gracefully stops that process.
+
+Usage:
   hermyx down [--config <path>]
 
 Options:
-  --config   Path to Hermyx config YAML file (default: ./hermyx.config.yaml)`)
+  --config   Path to Hermyx config YAML file (default: ./hermyx.config.yaml)
+
+Examples:
+  # Stop the instance started with ./hermyx.config.yaml
+  hermyx down
+
+  # Stop the instance started with a specific config file
+  hermyx down --config ./configs/prod.yaml`)
 }
 
 func printVersionHelp() {
-	fmt.Println(`Usage:
+	fmt.Println(`hermyx version - display the installed Hermyx version
+
+Usage:
+  hermyx version
+
+Examples:
   hermyx version`)
 }
 


### PR DESCRIPTION
Closes #3.

- Adds descriptions and Examples sections to up/down/init/version help text
- Fixes inconsistent tab/space alignment in the Available Commands list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded command-line help for the root command and `init`, `up`, `down`, and `version` commands.
  * Added clearer usage details, available options, descriptions, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->